### PR TITLE
Localize image links

### DIFF
--- a/map/notifications.properties
+++ b/map/notifications.properties
@@ -1,5 +1,6 @@
 
-National_Advantages_Notification=<body><img src="http://tripleamaps.sourceforge.net/images/tww/gamestartoptions.png"/></body>
+National_Advantages_Notification=<body><img src="gamestartoptions.png"/></body>
 Italy_declares_war_notification=<body>Italy have declared war on Britain and France!</body>
 Russia_declares_war_notification=<body>The Soviet Union has declared war on the European Axis!</body>
 USA_declares_war_notification=<body>The United States have entered the war on the side of the Allies!</body>
+


### PR DESCRIPTION
Convert absolute links to relative, the game engine is doing this automatically
which makes the 'http://sourceforge' part unused